### PR TITLE
Feedback changes!

### DIFF
--- a/model.py
+++ b/model.py
@@ -192,7 +192,7 @@ class DeepSpeech(nn.Module):
         package = torch.load(path, map_location=lambda storage, loc: storage)
         model = cls(rnn_hidden_size=package['hidden_size'], nb_layers=package['hidden_layers'],
                     labels=package['labels'], audio_conf=package['audio_conf'],
-                    rnn_type=supported_rnns[package['rnn_type']])
+                    rnn_type=supported_rnns[package['rnn_type']], bidirectional=package['bidirectional'])
         # the blacklist parameters are params that were previous erroneously saved by the model
         # care should be taken in future versions that if batch_norm on the first rnn is required
         # that it be named something else
@@ -212,7 +212,7 @@ class DeepSpeech(nn.Module):
     def load_model_package(cls, package, cuda=False):
         model = cls(rnn_hidden_size=package['hidden_size'], nb_layers=package['hidden_layers'],
                     labels=package['labels'], audio_conf=package['audio_conf'],
-                    rnn_type=supported_rnns[package['rnn_type']])
+                    rnn_type=supported_rnns[package['rnn_type']], bidirectional=package['bidirectional'])
         model.load_state_dict(package['state_dict'])
         if cuda:
             model = torch.nn.DataParallel(model).cuda()
@@ -230,7 +230,8 @@ class DeepSpeech(nn.Module):
             'rnn_type': supported_rnns_inv.get(model._rnn_type, model._rnn_type.__name__.lower()),
             'audio_conf': model._audio_conf,
             'labels': model._labels,
-            'state_dict': model.state_dict()
+            'state_dict': model.state_dict(),
+            'bidirectional': model._bidirectional
         }
         if optimizer is not None:
             package['optim_dict'] = optimizer.state_dict()

--- a/train.py
+++ b/train.py
@@ -56,8 +56,8 @@ parser.add_argument('--noise_max', default=0.5,
                     help='Maximum noise levels to sample from. Maximum 1.0', type=float)
 parser.add_argument('--no_shuffle', dest='no_shuffle', action='store_true',
                     help='Turn off shuffling and sample from dataset based on sequence length (smallest to largest)')
-parser.add_argument('--bidirectional', action='store_true', default=False, 
-                    help='add --bidirectional for bidirectional or omit for unidirectional rnn')
+parser.add_argument('--no_bidirectional', dest='bidirectional', action='store_false', default=True,
+                    help='Turn off bi-directional RNNs, introduces lookahead convolution')
 
 def to_np(x):
     return x.data.cpu().numpy()


### PR DESCRIPTION
Few changes that I came across when running the model on our server, code looks real good!

Changes:

- Fixed cuda support in the forward pass, torch zeros defaulted to a float based tensor
- The context was hardcoded to 3, I changed this to 20 to reflect the paper (also saw better testing results)
- Changed how the lookahead is constructed, previously it would be in the model regardless thus when you print the model it would be present (even when using bi-directional RNNs)
- It makes more sense to me to keep bi-directional as default as this is the standard deepspeech 2 architecture. I've flipped the flag to turn on uni-directional if turned off!

If you don't agree with any of the changes let me know!